### PR TITLE
adding presence tracking to pusher

### DIFF
--- a/lib/pusher.ex
+++ b/lib/pusher.ex
@@ -9,6 +9,7 @@ defmodule Pusher do
     children = [
       # Start the endpoint when the application starts
       supervisor(Pusher.Endpoint, []),
+      supervisor(Pusher.Presence, []),
       # Here you could define other workers and supervisors as children
       # worker(Pusher.Worker, [arg1, arg2, arg3]),
     ]

--- a/lib/pusher/is_a_helper.ex
+++ b/lib/pusher/is_a_helper.ex
@@ -1,0 +1,9 @@
+defmodule Pusher.IsAHelper do
+  def is_a_map?(%{}) do
+    true
+  end
+
+  def is_a_map?(_) do
+    false
+  end
+end

--- a/lib/pusher/is_a_helper.ex
+++ b/lib/pusher/is_a_helper.ex
@@ -1,9 +1,0 @@
-defmodule Pusher.IsAHelper do
-  def is_a_map?(%{}) do
-    true
-  end
-
-  def is_a_map?(_) do
-    false
-  end
-end

--- a/web/channels/event_channel.ex
+++ b/web/channels/event_channel.ex
@@ -1,6 +1,7 @@
 defmodule Pusher.EventChannel do
   use Phoenix.Channel
   import Guardian.Phoenix.Socket
+  alias Pusher.Presence
 
   def join("public:" <> _topic_id, _auth_msg, socket) do
     {:ok, socket}
@@ -9,6 +10,7 @@ defmodule Pusher.EventChannel do
   def join(topic, %{ "guardian_token" => token }, socket) do
     case sign_in(socket, token) do
       {:ok, authed_socket, guardian_params} ->
+        send(self, :after_join)
         claims = guardian_params[:claims]
         if permitted_topic?(claims["listen"], topic) do
           { :ok, %{ message: "Joined" }, authed_socket }
@@ -22,6 +24,18 @@ defmodule Pusher.EventChannel do
 
   def join(_room, _payload, _socket) do
     { :error, :authentication_required }
+  end
+
+  def handle_info(:after_join, socket) do
+    push socket, "presence_state", Presence.list(socket)
+    claims = current_claims(socket)
+    is_map = Pusher.IsAHelper.is_a_map?(claims["sub"])
+    if(is_map && Map.has_key?(claims["sub"], "email")) do
+      {:ok, _} = Presence.track(socket, current_resource(socket)["email"], %{
+        online_at: :os.system_time(:milli_seconds)
+      })
+    end
+    {:noreply, socket}
   end
 
   def handle_in(event, payload, socket = %{ topic: "public:" <> _ }) do

--- a/web/channels/event_channel.ex
+++ b/web/channels/event_channel.ex
@@ -28,12 +28,13 @@ defmodule Pusher.EventChannel do
 
   def handle_info(:after_join, socket) do
     push socket, "presence_state", Presence.list(socket)
-    claims = current_claims(socket)
-    is_map = Pusher.IsAHelper.is_a_map?(claims["sub"])
-    if(is_map && Map.has_key?(claims["sub"], "email")) do
-      {:ok, _} = Presence.track(socket, current_resource(socket)["email"], %{
-        online_at: :os.system_time(:milli_seconds)
-      })
+    case current_resource(socket) do
+      %{"email" => email} ->
+        {:ok, _} = Presence.track(socket, email, %{
+          online_at: :os.system_time(:milli_seconds)
+        })
+      _ ->
+        nil
     end
     {:noreply, socket}
   end

--- a/web/channels/presence.ex
+++ b/web/channels/presence.ex
@@ -1,0 +1,77 @@
+defmodule Pusher.Presence do
+  @moduledoc """
+  Provides presence tracking to channels and processes.
+
+  See the [`Phoenix.Presence`](http://hexdocs.pm/phoenix/Phoenix.Presence.html)
+  docs for more details.
+
+  ## Usage
+
+  Presences can be tracked in your channel after joining:
+
+      defmodule Pusher.MyChannel do
+        use Pusher.Web, :channel
+        alias Pusher.Presence
+
+        def join("some:topic", _params, socket) do
+          send(self, :after_join)
+          {:ok, assign(socket, :user_id, ...)}
+        end
+
+        def handle_info(:after_join, socket) do
+          {:ok, _} = Presence.track(socket, socket.assigns.user_id, %{
+            online_at: inspect(System.system_time(:seconds))
+          })
+          push socket, "presence_state", Presence.list(socket)
+          {:noreply, socket}
+        end
+      end
+
+  In the example above, `Presence.track` is used to register this
+  channel's process as a presence for the socket's user ID, with
+  a map of metadata. Next, the current presence list for
+  the socket's topic is pushed to the client as a `"presence_state"` event.
+
+  Finally, a diff of presence join and leave events will be sent to the
+  client as they happen in real-time with the "presence_diff" event.
+  See `Phoenix.Presence.list/2` for details on the presence datastructure.
+
+  ## Fetching Presence Information
+
+  The `fetch/2` callback is triggered when using `list/1`
+  and serves as a mechanism to fetch presence information a single time,
+  before broadcasting the information to all channel subscribers.
+  This prevents N query problems and gives you a single place to group
+  isolated data fetching to extend presence metadata.
+
+  The function receives a topic and map of presences and must return a
+  map of data matching the Presence datastructure:
+
+      %{"123" => %{metas: [%{status: "away", phx_ref: ...}],
+        "456" => %{metas: [%{status: "online", phx_ref: ...}]}
+
+  The `:metas` key must be kept, but you can extend the map of information
+  to include any additional information. For example:
+
+      def fetch(_topic, entries) do
+        query =
+          from u in User,
+            where: u.id in ^Map.keys(entries),
+            select: {u.id, u}
+
+        users = query |> Repo.all |> Enum.into(%{})
+
+        for {key, %{metas: metas}} <- entries, into: %{} do
+          {key, %{metas: metas, user: users[key]}}
+        end
+      end
+
+  The function above fetches all users from the database who
+  have registered presences for the given topic. The fetched
+  information is then extended with a `:user` key of the user's
+  information, while maintaining the required `:metas` field from the
+  original presence data.
+  """
+  use Phoenix.Presence, otp_app: :pusher,
+                        pubsub_server: Pusher.PubSub
+end


### PR DESCRIPTION
CC @trevorcreech @timcour @codeferret1 @azirbel 

This PR adds presence tracking to pusher. This change is actually pretty small most of the changes are resulting from the inline here docs that came out of a generated file.

You can find more context on Presence tracking in phoenix [here](http://work.stevegrossi.com/2016/07/11/building-a-chat-app-with-elixir-and-phoenix-presence/) including the some of the changes we are going to need to make on the client side in web.

This change should be safe to go out as is as doesn't change any existing behavior, it will just be a feature we don't use yet on the frontend side.