### PR TITLE
Set elixir node names in Procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
-web: yes | mix compile.protocols && elixir -pa _build/prod/consolidated -S mix phoenix.server
+# can't have dots in elixir node names, so replace them with underscores
+web: yes | mix compile.protocols && elixir --sname $(echo $DYNO | tr '.' '_') -pa _build/prod/consolidated -S mix phoenix.server


### PR DESCRIPTION
Phoenix Presence CRDT replication was failing because all our nodes are running as `nonode@nohost`. This was causing an infinite battle between the 3 servers all trying to use their version of presence.