### PR TITLE
Only enable presence on specific channels

### DIFF
--- a/web/channels/event_channel.ex
+++ b/web/channels/event_channel.ex
@@ -26,7 +26,7 @@ defmodule Pusher.EventChannel do
     { :error, :authentication_required }
   end
 
-  def handle_info(:after_join, socket) do
+  def handle_info(:after_join, socket = %{ topic: "private:presence:" <> _ }) do
     push socket, "presence_state", Presence.list(socket)
     case current_resource(socket) do
       %{"email" => email} ->
@@ -36,6 +36,10 @@ defmodule Pusher.EventChannel do
       _ ->
         nil
     end
+    {:noreply, socket}
+  end
+
+  def handle_info(:after_join, socket) do
     {:noreply, socket}
   end
 


### PR DESCRIPTION
Having presence on every channel was a lot of data, and upped our memory usage by 5x.

Now we only enable presence on channels having the pattern `private:presence:`