### PR TITLE
Allow subdomain wildcards for staging

### DIFF
--- a/config/staging.exs
+++ b/config/staging.exs
@@ -4,7 +4,7 @@ config :pusher, Pusher.Endpoint,
   http: [port: {:system, "PORT"}],
   pubsub: [adapter: Phoenix.PubSub.Redis, url: System.get_env("REDIS_URL")],
   url: [host: "staging-opendoor-pusher.herokuapp.com"],
-  check_origin: ["//demo.simplersell.com"],
+  check_origin: ["//demo.simplersell.com", "//*.herokuapp.com"],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :logger, level: :info


### PR DESCRIPTION
Review apps are intended to share the staging pusher (since review apps share the staging DB etc). They currently fail due to domain checks

![domian check](https://rpl.cat/uploads/7nI2qUqSaBzcLjiFWns_qjDwV7Jidwsyenlgn9mPtdE/public.png)

Reading https://github.com/phoenixframework/phoenix/pull/1353 seems to indicate that phoenix supports wildcards for subdomains