### PR TITLE
Correct the OTP version.

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,5 +1,5 @@
 # Erlang version
-erlang_version=20
+erlang_version=20.0
 
 # Elixir version
 elixir_version=1.4.5


### PR DESCRIPTION
The version for OTP requires the minor version also.
This is because for erlang it has a pre-built binary stored on s3 and it needs the actual version.

Bit brittle but that's the buildpack.