### PR TITLE
Dockerify pusher

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY . /app
 
 ENV MIX_ENV=docker
+ENV PORT=8585
 
 RUN mix local.hex --force
 RUN mix local.rebar --force

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM elixir:1.5
+
+RUN mkdir -p /app
+WORKDIR /app
+
+COPY . /app
+
+ENV MIX_ENV=docker
+
+RUN mix local.hex --force
+RUN mix local.rebar --force
+RUN mix deps.get
+RUN mix release
+
+CMD ["/usr/local/bin/elixir", "-S", "mix", "phoenix.server"]

--- a/config/docker.exs
+++ b/config/docker.exs
@@ -1,0 +1,16 @@
+node_name = "#{Mix.env()}#{System.os_time(:nanosecond)}"
+use Mix.Config
+
+config :pusher, Pusher.Endpoint,
+  http: [port: {:system, "PORT"}],
+  pubsub: [adapter: Phoenix.PubSub.Redis, url: System.get_env("REDIS_URL"), node_name: node_name],
+  debug_errors: true,
+  cache_static_lookup: false
+
+# Do not include metadata nor timestamps in development logs
+config :logger, :console, format: "[$level] $message\n"
+
+config :pusher, :authentication, secret: "development"
+config :guardian, Guardian, secret_key: "development"
+
+config :honeybadger, :environment_name, :dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3'
+
+services:
+  pusher:
+    environment:
+      - PORT=8585
+      - REDIS_URL=redis://redis:6379
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - 8585:8585
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:3.2
+    ports:
+      - 6379:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: '3'
 services:
   pusher:
     environment:
-      - PORT=8585
       - REDIS_URL=redis://redis:6379
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,8 @@ version: '3'
 services:
   pusher:
     environment:
-      - REDIS_URL=redis://redis:6379
-    build:
-      context: .
-      dockerfile: Dockerfile
+      - REDIS_URL=redis://redis
+    build: .
     ports:
       - 8585:8585
     depends_on:
@@ -14,5 +12,3 @@ services:
 
   redis:
     image: redis:3.2
-    ports:
-      - 6379:6379


### PR DESCRIPTION
This is intended for using docker to run pusher for local development. Hopefully in the future we can also deploy it on k8s instead of heroku

Also pushed to opendoor/pusher in docker hub