### PR TITLE
Allow all subdomains for auth

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -5,7 +5,7 @@ config :pusher, Pusher.Endpoint,
   http: [port: {:system, "PORT"}],
   pubsub: [adapter: Phoenix.PubSub.Redis, url: System.get_env("REDIS_URL"), node_name: node_name],
   url: [host: "opendoor-pusher.herokuapp.com"],
-  check_origin: ["//www.opendoor.com", "//admin.opendoor.com"],
+  check_origin: ["//*.opendoor.com"],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :logger, level: :info

--- a/config/staging.exs
+++ b/config/staging.exs
@@ -5,7 +5,7 @@ config :pusher, Pusher.Endpoint,
   http: [port: {:system, "PORT"}],
   pubsub: [adapter: Phoenix.PubSub.Redis, url: System.get_env("REDIS_URL"), node_name: node_name],
   url: [host: "staging-opendoor-pusher.herokuapp.com"],
-  check_origin: ["//demo.simplersell.com", "//admin.simplersell.com", "//*.herokuapp.com"],
+  check_origin: ["//*.simplersell.com", "//*.herokuapp.com"],
   secret_key_base: System.get_env("SECRET_KEY_BASE")
 
 config :logger, level: :info


### PR DESCRIPTION
## Problem

We want to connect to pusher from other subdomains on opendoor and simplersell (i.e. `consumer.opendoor.com`)

## Solution

Allow all subdomains of opendoor and simplersell to connect to pusher