### PR TITLE
Log topic on publish

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM elixir:1.5
+# keep in sync with elixir_buildpack.config
+FROM elixir:1.4.5
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,7 +1,7 @@
 # Erlang version
 erlang_version=20.0
 
-# Elixir version
+# Elixir version, keep in sync with Dockerfile
 elixir_version=1.4.5
 
 # Always rebuild from scratch on every deploy?

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Pusher.Mixfile do
      compilers: [:phoenix] ++ Mix.compilers,
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   # Configuration for the OTP application

--- a/web/channels/event_channel.ex
+++ b/web/channels/event_channel.ex
@@ -10,7 +10,7 @@ defmodule Pusher.EventChannel do
   def join(topic, %{ "guardian_token" => token }, socket) do
     case sign_in(socket, token) do
       {:ok, authed_socket, guardian_params} ->
-        send(self, :after_join)
+        send(self(), :after_join)
         claims = guardian_params[:claims]
         if permitted_topic?(claims["listen"], topic) do
           { :ok, %{ message: "Joined" }, authed_socket }

--- a/web/controllers/publish_controller.ex
+++ b/web/controllers/publish_controller.ex
@@ -1,4 +1,6 @@
 defmodule Pusher.PublishController do
+  require Logger
+
   use Pusher.Web, :controller
 
   plug :authenticate
@@ -16,6 +18,7 @@ defmodule Pusher.PublishController do
   defp broadcast_event(event_params = %{ "topic" => topic, "event" => event }) do
     message = event_params["payload"] || %{}
     Pusher.Endpoint.broadcast! topic, event, message
+    Logger.info("Published event to #{topic}")
   end
 
   defp broadcast_event(_), do: :ok


### PR DESCRIPTION
Will let us see if there's a bunch of `deploys:web` events being published.

```
pusher_1  | [info] POST /api/publish
pusher_1  | [debug] Processing by Pusher.PublishController.publish/2
pusher_1  |   Parameters: %{"event" => "msg", "payload" => %{"version" => "abc"}, "topic" => "deploys:web"}
pusher_1  |   Pipelines: [:api]
pusher_1  | [info] Published event to deploys:web
pusher_1  | [info] Sent 200 in 51ms
```

Note: debug logs don't show up in prod

## Test plan
* ran locally with docker, pushed from local rails console